### PR TITLE
Always copy the record ID when publishing

### DIFF
--- a/src/Concerns/HasPublishing.php
+++ b/src/Concerns/HasPublishing.php
@@ -151,12 +151,15 @@ trait HasPublishing
         // find or make the published record
         $published = $this->publishedRecord ?? static::make()->setRevisorContext(RevisorContext::Published);
 
+        // Temporarily unhide hidden attributes so they can be copied
+        $hiddenAttributes = $this->getHidden();
+        $this->setHidden([]);
+
         // copy the attributes from the draft record to the published record
         $published->forceFill($this->attributesToArray());
 
-        // Ensure ID is copied even if it's hidden
-        $idField = $this->primaryKey;
-        $published->{$idField} = $this->{$idField};
+        // Restore hidden attributes
+        $this->setHidden($hiddenAttributes);
 
         // save the published record
         $published->save();

--- a/src/Concerns/HasPublishing.php
+++ b/src/Concerns/HasPublishing.php
@@ -154,6 +154,10 @@ trait HasPublishing
         // copy the attributes from the draft record to the published record
         $published->forceFill($this->attributesToArray());
 
+        // Ensure ID is copied even if it's hidden
+        $idField = $this->primaryKey;
+        $published->{$idField} = $this->{$idField};
+
         // save the published record
         $published->save();
 

--- a/src/Concerns/HasVersioning.php
+++ b/src/Concerns/HasVersioning.php
@@ -104,6 +104,11 @@ trait HasVersioning
             ->add('id')
             ->toArray();
 
+
+        // Temporarily unhide hidden attributes so they can be copied
+        $hiddenAttributes = $this->getHidden();
+        $this->setHidden([]);
+
         $attributes = collect($this->attributesToArray())
             ->except($exceptAttributes)
             ->merge([
@@ -111,6 +116,9 @@ trait HasVersioning
                 'version_number' => ($this->versionRecords()->max('version_number') ?? 0) + 1,
             ])
             ->toArray();
+
+        // Restore hidden attributes
+        $this->setHidden($hiddenAttributes);
 
         $version = static::make()->setRevisorContext(RevisorContext::Version)->forceFill($attributes);
         $this->setVersionAsCurrent($version);

--- a/tests/HasPublishingTest.php
+++ b/tests/HasPublishingTest.php
@@ -119,7 +119,7 @@ it('does not double encoded json columns', function () {
     expect($page->publishedRecord->metadata)->toBe($jsonData);
 });
 
-it('copies the record ID when publishing, even if hidden', function () {
+it('copies hidden attributes when publishing', function () {
     Revisor::createTableSchemas('hidden_id_models', function (Blueprint $table) {
         $table->id();
         $table->string('slug');

--- a/tests/Models/HiddenIdModel.php
+++ b/tests/Models/HiddenIdModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Indra\Revisor\Tests\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Indra\Revisor\Concerns\HasRevisor;
+use Indra\Revisor\Contracts\HasRevisor as HasRevisorContract;
+
+class HiddenIdModel extends Model implements HasRevisorContract
+{
+    use HasRevisor;
+
+    protected string $baseTable = 'hidden_id_models';
+
+    protected $fillable = [
+        'slug',
+    ];
+
+    protected $hidden = [
+        'id'
+    ];
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}


### PR DESCRIPTION
Fixes #6 

This only handles the primary key column since that's what's required to actually link the records. A more comprehensive solution would copy all of the hidden columns, but that runs into the issue of JSON columns being double-encoded, which I don't have time to solve right now. If users have other hidden columns they will be able to copy them manually after publish.