### PR TITLE
Ensure versions table is dropped before drafts

### DIFF
--- a/src/Revisor.php
+++ b/src/Revisor.php
@@ -140,9 +140,10 @@ class Revisor
     public function getAllTablesFor(string $baseTableName): Collection
     {
         return collect([
+            // Version table should be returned first so it gets dropped first in dropTableSchemasIfExists
+            $this->getVersionTableFor($baseTableName),
             $this->getDraftTableFor($baseTableName),
             $this->getPublishedTableFor($baseTableName),
-            $this->getVersionTableFor($baseTableName),
         ]);
     }
 


### PR DESCRIPTION
Versions table must be dropped before drafts to avoid foreign key constraint violations

Fixes #10 